### PR TITLE
Run tests before start. Add start-no-test script to package.json to start without tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Another react dashboard component",
   "main": "./dist/react-dashboard.min.js",
   "scripts": {
-    "start": "bash start.sh",
+    "start": "npm run test && bash start.sh",
+    "start-no-test": "bash start.sh",
     "build": "webpack --config webpack.config.production.js",
     "test": "bash runtests.sh",
     "lint": "eslint src"


### PR DESCRIPTION
## Description

Try to keep us honest.
## Acceptance criteria
- [ ] `npm run start` - runs unit tests and then starts dev server
- [ ] `npm run start-no-test` - start dev server without running unit tests
