### PR TITLE
Fix react-select version

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "phantomjs": "^2.1.7",
     "react-nvd3": "git+https://github.com/NuCivic/react-nvd3.git",
     "react-router": "^2.7.0",
-    "react-select": "git+https://github.com/JedWatson/react-select.git",
+    "react-select": "git+https://github.com/JedWatson/react-select.git#v1.0.0-rc.1",
     "topojson": "^1.6.24"
   },
   "peerDependencies": {


### PR DESCRIPTION
Version is tied to react-select master and updates in the upstream library are breaking current implementations.