### PR TITLE
Add an inner class to the Card Component

### DIFF
--- a/src/components/BaseComponent.js
+++ b/src/components/BaseComponent.js
@@ -9,7 +9,7 @@ import Registry from '../utils/Registry';
 import { makeKey } from '../utils/utils';
 import { qFromParams, getOwnQueryParams, getFID, objToQueryString } from '../utils/paramRouting';
 
-const CARD_VARS = ['header', 'footer', 'iconClass', 'cardStyle', 'cardClasses', 'subheader', 'topmatter', 'subheader2', 'topmatter2', 'footerHeader', 'footerSubheader', 'bottommatter', 'footerSubheader2', 'bottommatter2'];
+const CARD_VARS = ['header', 'footer', 'iconClass', 'cardStyle', 'cardClasses', 'cardInnerClasses', 'subheader', 'topmatter', 'subheader2', 'topmatter2', 'footerHeader', 'footerSubheader', 'bottommatter', 'footerSubheader2', 'bottommatter2'];
 
 export default class BaseComponent extends Component {
 

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -14,6 +14,7 @@ export default class Card extends Component {
     let style = props.style || {};
     let regions = {};
     let classNames = (props.cardClasses || []).join(' ') || '';
+    let classInnerNames = (props.cardInnerClasses || []).join(' ') || '';
 
     CARD_REGIONS.forEach(region => {
       if (props[region]) {
@@ -28,22 +29,24 @@ export default class Card extends Component {
 
     return (
       <div className={'card card-' + props.cardStyle + ' ' + classNames} style={style}>
-        <div className="card-top">
-          {regions.header}
-          {regions.subheader}
-          {regions.topmatter}
-          {regions.subheader2}
-          {regions.topmatter2}
-        </div>
-        <div className="card-content">
-          {props.children}
-        </div>
-        <div className="card-bottom">
-          {regions.footerHeader}
-          {regions.footerSubheader}
-          {regions.bottommatter}
-          {regions.footerSubheader2}
-          {regions.bottommatter2}
+        <div className={ 'card-inner ' + classInnerNames }>
+          <div className="card-top">
+            {regions.header}
+            {regions.subheader}
+            {regions.topmatter}
+            {regions.subheader2}
+            {regions.topmatter2}
+          </div>
+          <div className="card-content">
+            {props.children}
+          </div>
+          <div className="card-bottom">
+            {regions.footerHeader}
+            {regions.footerSubheader}
+            {regions.bottommatter}
+            {regions.footerSubheader2}
+            {regions.bottommatter2}
+          </div>
         </div>
       </div>
     )


### PR DESCRIPTION
Sometimes using the bootstrap grid system is diffecult without an inner div element holding all the internal card structure (`card-top`, `card-content`, `card-bottom`). For example to surround the Chart with [panel](http://getbootstrap.com/components/#panels) like border.

![image](https://user-images.githubusercontent.com/1914306/28473002-509ee004-6e43-11e7-8074-30ca1d73363a.png)

This Pull Request wraps the Card's element inside a div with the `card-inner` class and add support for a new Card setting option named "cardInnerClasses" to append classes to the div.