### PR TITLE
GPBW-91:highlight links

### DIFF
--- a/examples/settings.js
+++ b/examples/settings.js
@@ -80,10 +80,11 @@ export var settings = {
           className: 'col-md-6',
           name: 'specialty-autocomplete',
           id: 'specialty-autocomplete',
+          key: 'auto-complete-1',
           className: 'specialty-autocomplete',
           field: 'YearMonth',
           action: 'filter', // sort / groupBy / etc
-          willFilter: ['climateData'], // array of dkanDataResources keys that filters affect 
+          willFilter: ['climateData'], // array of dkanDataResources keys that filters affect
           data: [
             [
               { label: '2010', value: '2010' },
@@ -106,6 +107,8 @@ export var settings = {
           type: 'Metric',
           cardStyle: 'metric',
           iconClass: 'fa fa-level-up',
+          id: 'metric-1',
+          key: 'key-1',
           className: 'col-md-4',
           background: "#00b3b3",
           caption: 'Maximum Temp.',
@@ -126,6 +129,8 @@ export var settings = {
           type: 'Metric',
           cardStyle: 'metric',
           iconClass: 'fa fa-level-down',
+          id: 'metric-2',
+          key: 'key-2',
           className: 'col-md-4',
           background: '#009999',
           caption: 'Minimum Temp.',
@@ -138,8 +143,10 @@ export var settings = {
         },
         {
           type: 'Metric',
-          cardStyle: 'metric',     
+          cardStyle: 'metric',
           iconClass: 'fa fa-fire',
+          id: 'metric-3',
+          key: 'key-3',
           className: 'col-md-4',
           caption: 'Average Temp/',
           background: '#004d4d',
@@ -161,6 +168,7 @@ export var settings = {
           type: 'Choropleth',
           cardStyle: 'map',
           iconClass: 'fa fa-balance-scale',
+          key: 'key-1',
           header: 'Palmer Hydrological Drought Index',
           format: 'topojson',
           dataHandlers: [
@@ -205,6 +213,7 @@ export var settings = {
           type: 'Chart',
           cardStyle: 'chart',
           header: 'Standard Precipitation Index',
+          key: 'chart-1',
           iconClass: 'fa fa-cloud',
           dataHandlers: [ 'getBarChartData' ],
           stateHandlers: [
@@ -219,6 +228,29 @@ export var settings = {
             y: 'y',
             height: 800
           }
+        }
+      ]
+    },
+    {
+      id: 'highlight-row',
+      className: 'row',
+      children: [
+        {
+          type: 'Highlight',
+          key: 'highlight1',
+          data: [
+            {
+              cols: [
+                {rows:[
+                  {label: 'label 1', val: 'Value 1'},
+                  {label: 'Full Link', val: 'This is a full link', url:'http://google.com', isLink:true}
+                ]},
+                {rows:[
+                  {label: 'label 2', val: 'Value 2'}
+                ]}
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -202,12 +202,14 @@ export default class Dashboard extends BaseComponent {
   getRegion(region) {
     return (
       <div key={region.id} id={region.id} className={region.className} >
-        {region.children.map( (element, key) => {
+        {region.children.map( (element, index) => {
           // if it isn't a react element, the element is a settings object
 
           let props = this.updateProps(element);
           element.isFetching = this.state.isFetching;
-          let el = (React.isValidElement(element)) ? element : React.createElement(Registry.get(element.type), props);
+          let el = (React.isValidElement(element)) ?
+            element :
+            React.createElement(Registry.get(element.type), props);
           return el;
         })}
       </div>
@@ -237,10 +239,10 @@ export default class Dashboard extends BaseComponent {
   getRegions() {
     let regions;
     if (this.props.regions) {
-      regions = this.props.regions.map( (region, key) => {
+      regions = this.props.regions.map( (region, index) => {
         if (region.multi) {
           let multiRegionKey = this.getChildData(region);
-          region.key = key;
+          region.key = index;
           region.children = region.elements[multiRegionKey];
         }
 

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -4,8 +4,13 @@ import BaseComponent from './BaseComponent';
 import Card from './Card';
 
 export default class Highlight extends BaseComponent {
+
   render() {
     let cols = this.props.data[0].cols || [];
+
+    const existy = (obj) => {
+      return obj != null;
+    };
 
     return (
       <Card {...this.state.cardVariables}>
@@ -14,13 +19,46 @@ export default class Highlight extends BaseComponent {
               return <div className={"highlight-col highlight-cols-" + cols.length} key={i}>
                 { col.rows.map( (row, j) => {
                   let output = [];
+                  // Create label & val keys by stripping spaces from their values and
+                  // appending the map index.
+                  let labelKey = (row.label.replace(/\s/g,'-')).toLowerCase() + j;
+                  let valKey = (row.val.slice(0,8)).replace(/\s/g,'-').toLowerCase() + j;
+
                   if (row.isLink) {
-                    output.push(<span className="highlight-val">
-                               <a href={row.val}>{ row.label ? row.label : row.val}</a>
-                             </span>)
+
+                     let label = existy(row.label);
+                     let value = existy(row.val);
+                     let url = existy(row.url);
+
+                    switch (true) {
+                      case (label && value && url) :
+                        output.push(<span className="highlight-label" key={labelKey}>{ row.label }</span>);
+                        output.push(<span className="highlight-val" key={valKey}>
+                          <a href={ row.url }>{ row.val }</a>
+                        </span>);
+                        break;
+                      case (!label && value && url):
+                        output.push(<span className="highlight-val" key={valKey}>
+                          <a href={ row.url }>{ row.val }</a>
+                        </span>);
+                        break;
+                      case (label && !value && url):
+                        output.push(<span className="highlight-val" key={labelKey}>
+                          <a href={ row.url }>{ row.label }</a>
+                        </span>);
+                        break;
+                      case ((label || value) && !url):
+                        output.push(<span className="highlight-val" key={row.val ? valKey : labelKey}>
+                               <a href={row.val ? row.val : row.label}>{ row.label ? row.label : row.val}</a>
+                             </span>);
+                        break;
+                      default:
+                        console.log('invalid or empty row values.')
+                    }
+
                   } else {
-                    output.push(<span className="highlight-label">{ row.label }</span>)
-                    output.push(<span className="highlight-val">{ row.val }</span>)
+                    output.push(<span className="highlight-label" key={labelKey}>{ row.label }</span>);
+                    output.push(<span className="highlight-val" key={valKey}>{ row.val }</span>)
                   }
                   return (
                     <div className="highlight-row" key={j}>


### PR DESCRIPTION
This expands the function for creating links in the Highlight component. Different case scenarios are added to maintain backwards compatibility in dashboards where URLs have been created with just row.label & row.val.

New format: 
`{label: 'Full Link', val: 'This is a full link', url:'http://google.com', isLink:true}`
Results in:
**Full Link** [This is a full link](http://google.com)